### PR TITLE
standard-file/intro: fix link to client dev guide

### DIFF
--- a/app/views/website/markdown/standard-file/intro.md
+++ b/app/views/website/markdown/standard-file/intro.md
@@ -12,7 +12,7 @@ Please visit [standardfile.org](https://standardfile.org) for the full specifica
 
 ## Next Steps
 
-Check out the [client development guide](https://github.com/standardnotes/doc/blob/master/Client%20Development%20Guide.md) for a practical guide to developing an application on top of Standard File.
+Check out the [client development guide](/standard-file/client-development) for a practical guide to developing an application on top of Standard File.
 
 See [Standard Notes Developer Resources](https://standardnotes.org/developers).
 


### PR DESCRIPTION
I found the broken link while browsing the docs. This should fix it.