### PR TITLE
standard-file/intro: fix link (2nd try)

### DIFF
--- a/app/views/website/markdown/standard-file/intro.md
+++ b/app/views/website/markdown/standard-file/intro.md
@@ -12,7 +12,7 @@ Please visit [standardfile.org](https://standardfile.org) for the full specifica
 
 ## Next Steps
 
-Check out the [client development guide](/standard-file/client-development) for a practical guide to developing an application on top of Standard File.
+Check out the [client development guide](/standard-file/client-development-guide) for a practical guide to developing an application on top of Standard File.
 
 See [Standard Notes Developer Resources](https://standardnotes.org/developers).
 


### PR DESCRIPTION
I have just seen on the website that my earlier PR #7 was wrong. I had mistakenly taken the name of the Markdown file (client-development) and not the parameterized title (client-development-guide).

Sorry for that. Now, it should really fix the link.