### PR TITLE
Update documentation for self-hosting with Docker

### DIFF
--- a/app/views/website/markdown/self-hosting/docker.md
+++ b/app/views/website/markdown/self-hosting/docker.md
@@ -101,19 +101,19 @@ These instructions make the following assumptions:
 
 10. Access the server locally:
 
-   ``` bash
-   $ curl {domain name}
-   <!doctype html>
-   <html>
-     ...
-     <body>
-       <h1> Hi! You're not supposed to be here. </h1>
+    ``` bash
+    $ curl {domain name}
+    <!doctype html>
+    <html>
+      ...
+      <body>
+        <h1> Hi! You're not supposed to be here. </h1>
 
-       <p> You might be looking for the <a href="https://app.standardnotes.org"> Standard Notes Web App</a> or the main <a href="https://standardnotes.org"> Standard Notes Website</a>. </p>
+        <p> You might be looking for the <a href="https://app.standardnotes.org"> Standard Notes Web App</a> or the main <a href="https://standardnotes.org"> Standard Notes Website</a>. </p>
 
-     </body>
-   </html>
-   ```
+      </body>
+    </html>
+    ```
 
 11. You're done!
 

--- a/app/views/website/markdown/self-hosting/docker.md
+++ b/app/views/website/markdown/self-hosting/docker.md
@@ -1,10 +1,7 @@
 These instructions make the following assumptions:
 - You've just finished setting up a Linux server (say, Ubuntu 16.04 64-bit) and have installed Docker on it.
-
 - You've configured your security groups to allow for incoming SSH connections from your local IP.
-
 - You've configured a domain name (or subdomain) to point to your server's IP address.
-
 - You've configured the DNS to enable HTTPS for your domain (say, using Cloudflare).
 
 ### Getting started
@@ -22,7 +19,7 @@ These instructions make the following assumptions:
    $ sudo apt-get upgrade
    ```
 
-3. Install git
+3. Install Git:
 
    ``` bash
    $ sudo apt-get update
@@ -37,53 +34,53 @@ These instructions make the following assumptions:
    $ cd ruby-server
    ```
 
-5. Create .env.{app|db}.production files in the project's root directory. Add environment variables (see Environment variables for full listing):
+5. Create `.env.{app|db}.production` files in the project's Docker environment directory:
 
    ``` bash
    $ cd $PROJECT_ROOT/docker/environments/
    $ cp .env.app.producion.template .env.app.production
-   $ vim .env.app.production
+   $ cp .env.db.producion.template .env.db.production
    ```
 
-   Insert:
-
-   ```
+   Ensure that the `.env.app.production` file contains the below environment variables:
+   
+   ```bash
+   $ cat .env.app.production
    RAILS_ENV=production
    SECRET_KEY_BASE=use "bundle exec rake secret"
    RAILS_SERVE_STATIC_FILES=true
 
-   DB_HOST=localhost
-   DB_PORT=3306
-   DB_DATABASE=items
+   DB_CONNECTION=mysql
+   DB_HOST=db
+   DB_DATABASE=standardfile
    DB_USERNAME=root
    DB_PASSWORD=
    ```
 
+   Ensure that the `.env.db.production` file contains the below environment variable:
+
    ``` bash
-   $ cd $PROJECT_ROOT/docker/environments/
-   $ cp .env.db.producion.template .env.db.production
-   $ vim .env.db.production
-   ```
-
-   Insert:
-
-   ```
+   $ cat .env.db.production
    MYSQL_ROOT_PASSWORD=
    ```
+   
+   If you set a password for the root database user under `DB_PASSWORD` in `.env.db.production`, you must set the same password under `MYSQL_ROOT_PASSWORD` in `.env.db.production`.
 
-6. Build the services, without starting them:
+6. Build the services without starting them:
+
    ``` bash
    $ docker-compose build
    ```
 
-6. Run the app service to compile the assets:
+6. Run the `app` service to compile the assets:
+
    ``` bash
-   $ docker-compose -f docker-compose.yml -f docker-compose.production.yml up app
+   $ docker-compose -f docker-compose.yml -f docker-compose.production.yml up app -d
    $ docker-compose exec app bundle exec rake assets:precompile
    ```
 
    At this point the precompiled assets are stored in the `public/`
-   folder of the host. Nginx container will mount the folder as volume
+   folder of the host. The Nginx container will mount the folder as a volume
    and get the assets.
 
    ``` bash
@@ -96,12 +93,14 @@ These instructions make the following assumptions:
    $ docker-compose -f docker-compose.yml -f docker-compose.production.yml up -d
    ```
 
-7. Login to the `app` service to initialize project:
+7. Login to the `app` service to initialize the project:
+
    ``` bash
    $ docker-compose exec app bundle exec rake db:create db:migrate
    ```
 
 8. Access the server locally:
+
   ``` bash
   $ curl {domain name}
   <!doctype html>
@@ -118,10 +117,10 @@ These instructions make the following assumptions:
 
 9. You're done!
 
-## Using your new server
+### Using your new server
 
 You can immediately start using your new server by using the Standard Notes app at https://app.standardnotes.org.
 
-In the account menu, choose Advanced Options when signing in to specify your server.
+In the account menu, choose `Advanced Options` when signing in to specify your server.
 
 Then, register for a new account, and begin using your private new secure Standard File server!

--- a/app/views/website/markdown/self-hosting/docker.md
+++ b/app/views/website/markdown/self-hosting/docker.md
@@ -72,7 +72,7 @@ These instructions make the following assumptions:
    $ docker-compose build
    ```
 
-6. Run the `app` service to compile the assets:
+7. Run the `app` service to compile the assets:
 
    ``` bash
    $ docker-compose -f docker-compose.yml -f docker-compose.production.yml up app -d
@@ -87,35 +87,35 @@ These instructions make the following assumptions:
    $ docker-compose down
    ```
 
-6. Start the services:
+8. Start the services:
 
    ``` bash
    $ docker-compose -f docker-compose.yml -f docker-compose.production.yml up -d
    ```
 
-7. Login to the `app` service to initialize the project:
+9. Login to the `app` service to initialize the project:
 
    ``` bash
    $ docker-compose exec app bundle exec rake db:create db:migrate
    ```
 
-8. Access the server locally:
+10. Access the server locally:
 
-  ``` bash
-  $ curl {domain name}
-  <!doctype html>
-  <html>
-    ...
-    <body>
-      <h1> Hi! You're not supposed to be here. </h1>
+   ``` bash
+   $ curl {domain name}
+   <!doctype html>
+   <html>
+     ...
+     <body>
+       <h1> Hi! You're not supposed to be here. </h1>
 
-      <p> You might be looking for the <a href="https://app.standardnotes.org"> Standard Notes Web App</a> or the main <a href="https://standardnotes.org"> Standard Notes Website</a>. </p>
+       <p> You might be looking for the <a href="https://app.standardnotes.org"> Standard Notes Web App</a> or the main <a href="https://standardnotes.org"> Standard Notes Website</a>. </p>
 
-    </body>
-  </html>
-  ```
+     </body>
+   </html>
+   ```
 
-9. You're done!
+11. You're done!
 
 ### Using your new server
 


### PR DESCRIPTION
Mainly updating the environment variables from `.env.app.production` as well as minor formatting issues.

I've seen standardfile/ruby-server#68 and I know the `=`s were changed to `:`, but `=` works fine for me and is more consistent with the other environment variables.