### PR TITLE
fix: enforce master branch for stable code

### DIFF
--- a/docs/self-hosting/docker.md
+++ b/docs/self-hosting/docker.md
@@ -45,9 +45,11 @@ SSH into your server and follow the steps below:
 
    ```bash
    $ cd ~
-   $ git clone https://github.com/standardnotes/syncing-server.git
+   $ git clone --single-branch --branch master https://github.com/standardnotes/syncing-server.git
    $ cd syncing-server
    ```
+
+> **Note:** The `master` branch has the latest, stable code. Use this branch in production environments.
 
 1. Install `bundler` and then install gems
 

--- a/docs/self-hosting/ec2-nginx.md
+++ b/docs/self-hosting/ec2-nginx.md
@@ -164,9 +164,11 @@ These instructions make the following assumptions:
 
    ```bash
    cd ~
-   git clone https://github.com/standardnotes/syncing-server.git
+   git clone --single-branch --branch master https://github.com/standardnotes/syncing-server.git
    cd syncing-server
    ```
+
+**Note:** The `master` branch has the latest, stable code. Use this branch in production environments.
 
 1. Setup project:
 

--- a/docs/self-hosting/heroku.md
+++ b/docs/self-hosting/heroku.md
@@ -20,7 +20,7 @@ hide_table_of_contents: false
 
 1. Configure the Heroku Command Line Interface (CLI) using these steps: [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli).
 
-1. Deploy the Standard Notes server to your account using the following deploy link: https://heroku.com/deploy?template=https://github.com/standardnotes/syncing-server
+1. Deploy the Standard Notes server to your account using the following deploy link: https://heroku.com/deploy?template=https://github.com/standardnotes/syncing-server/tree/master
 
 1. Install a MySQL add-on. Here we'll use the JawsDB add-on: https://elements.heroku.com/addons/jawsdb. If you already have a database, you can skip this step.
 


### PR DESCRIPTION
- [x] Update [Docker](https://docs.standardnotes.org/self-hosting/docker) and [EC2](https://docs.standardnotes.org/self-hosting/ec2-nginx) guides to clone the `master` branch
- [x] Update `heroku` deploy link to use the `master` branch