### PR TITLE
Add missing `Shift` to Bold editor ordered & unordered list keyboard shortcuts

### DIFF
--- a/docs/usage/bold-editor.md
+++ b/docs/usage/bold-editor.md
@@ -50,8 +50,8 @@ The search feature in the [Minimist editor](https://standardnotes.org/extensions
 | Superscript        | Ctrl/⌘ + h                       |
 | Subscript          | Ctrl/⌘ + l                       |
 | Link               | Ctrl/⌘ + k                       |
-| Ordered List       | Ctrl/⌘ + 7                       |
-| Unordered List     | Ctrl/⌘ + 8                       |
+| Ordered List       | Ctrl/⌘ + Shift + 7               |
+| Unordered List     | Ctrl/⌘ + Shift + 8               |
 | Outdent            | Ctrl/⌘ + [                       |
 | Indent             | Ctrl/⌘ + ]                       |
 | Normal (Pagagraph) | Ctrl/⌘ + Alt + 0                 |


### PR DESCRIPTION
Noticed shift key was missing from ordered and unordered list commands. See redactor docs: https://imperavi.com/redactor/docs/get-started/shortcuts/#s-predefined%20shortcuts