### PR TITLE
Fix code example for negation

### DIFF
--- a/docs/usage/tags.md
+++ b/docs/usage/tags.md
@@ -117,7 +117,7 @@ Show all notes that have tags `Blog.Scheduled` or `Blog.Published`.
 You can also use the not predicate to negate an expression. For example, to show all notes that do not have the `Unread` tag:
 
 ```
-!["Read", "ignored", "not", ["tags", "includes", ["title", "=", "Unread"]]]
+!["Read", "tags", "not", ["tags", "includes", ["title", "=", "Unread"]]]
 ```
 
 The not predicate can be combined with the compound operators. For example, to show all notes that have the `Blog` tag but not the `Blog.Published` one:


### PR DESCRIPTION
I was trying to create a smart tag with negation and found that the code example which set the note attribute as `ignored` does not produce correct expected behavior.

I'm on desktop version 3.5.18.

I have notes tagged `private`, I want to create a smart tag to view notes that doesn't tagged `private`.

This smart tag works:
```
!["Public", "tags", "not", ["tags", "includes", ["title", "startsWith", "private"]]]
```

This smart tag does not:
```
!["Public", "ignored", "not", ["tags", "includes", ["title", "startsWith", "private"]]]
```
I'm not sure if this problem only apply for the negation, or also apply to other examples that use `ignored` attribute.
